### PR TITLE
Compact - Just Like the Simulations [Example Pull Request]

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -26,7 +26,17 @@ url = "https://github.com/DartRuffian/Mine-Detector-Fixes"
 
 [hemtt.launch.default]
 workshop = [
-    "450814997"  # CBA
+    "450814997" # CBA
+]
+presets = []
+dlc = []
+optionals = []
+parameters = []
+
+[hemtt.launch.jlts]
+workshop = [
+    "450814997", # CBA
+    "1940589429" # JLTS
 ]
 presets = []
 dlc = []

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -26,7 +26,8 @@ url = "https://github.com/DartRuffian/Mine-Detector-Fixes"
 
 [hemtt.launch.default]
 workshop = [
-    "450814997" # CBA
+    "450814997",  # CBA
+    "2369477168", # ADT"
 ]
 presets = []
 dlc = []
@@ -35,8 +36,9 @@ parameters = []
 
 [hemtt.launch.jlts]
 workshop = [
-    "450814997", # CBA
-    "1940589429" # JLTS
+    "450814997",  # CBA
+    "2369477168", # ADT"
+    "1940589429"  # JLTS
 ]
 presets = []
 dlc = []

--- a/Tools/launch.bat
+++ b/Tools/launch.bat
@@ -1,3 +1,8 @@
 @echo off
-hemtt.exe launch
+if "%~1"=="" (
+    set option=default
+) else (
+    set option=%1
+)
+hemtt.exe launch %option%
 pause

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -13,4 +13,16 @@ class CfgWeapons
             type = TYPE_BIPOD;
         };
     };
+
+    class JLTS_droidCaller: CBA_MiscItem
+    {
+        detectRange = 0;
+        simulation = "Weapon";
+        type = TYPE_ITEM;
+
+        class ItemInfo: CBA_MiscItem_ItemInfo
+        {
+            type = TYPE_BIPOD;
+        };
+    };
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -5,4 +5,5 @@ class CfgWeapons
     SIMPLE_PATCH(JLTS_credits_10);
     SIMPLE_PATCH(JLTS_droidCaller);
     SIMPLE_PATCH(JLTS_drugs_electrolit);
+    SIMPLE_PATCH(JLTS_ids_gar_navy);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -2,27 +2,6 @@ class CfgWeapons
 {
     class CBA_MiscItem;
     class CBA_MiscItem_ItemInfo;
-    class JLTS_credits_10: CBA_MiscItem
-    {
-        detectRange = 0;
-        simulation = "Weapon";
-        type = TYPE_ITEM;
-
-        class ItemInfo: CBA_MiscItem_ItemInfo
-        {
-            type = TYPE_BIPOD;
-        };
-    };
-
-    class JLTS_droidCaller: CBA_MiscItem
-    {
-        detectRange = 0;
-        simulation = "Weapon";
-        type = TYPE_ITEM;
-
-        class ItemInfo: CBA_MiscItem_ItemInfo
-        {
-            type = TYPE_BIPOD;
-        };
-    };
+    SIMPLE_PATCH(JLTS_credits_10);
+    SIMPLE_PATCH(JLTS_droidCaller);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -4,4 +4,5 @@ class CfgWeapons
     class CBA_MiscItem_ItemInfo;
     SIMPLE_PATCH(JLTS_credits_10);
     SIMPLE_PATCH(JLTS_droidCaller);
+    SIMPLE_PATCH(JLTS_drugs_electrolit);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -8,5 +8,6 @@ class CfgWeapons
     SIMPLE_PATCH(JLTS_ids_gar_navy);
     SIMPLE_PATCH(JLTS_intel_holocron_jedi);
     SIMPLE_PATCH(JLTS_repairkit_weapon);
+    SIMPLE_PATCH(JLTS_riot_shield_item);
     SIMPLE_PATCH(JLTS_scanner_police);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -2,12 +2,7 @@ class CfgWeapons
 {
     class CBA_MiscItem;
     class CBA_MiscItem_ItemInfo;
-    SIMPLE_PATCH(JLTS_credits_10);
-    SIMPLE_PATCH(JLTS_droidCaller);
-    SIMPLE_PATCH(JLTS_drugs_electrolit);
-    SIMPLE_PATCH(JLTS_ids_gar_navy);
-    SIMPLE_PATCH(JLTS_intel_holocron_jedi);
     SIMPLE_PATCH(JLTS_repairkit_weapon);
     SIMPLE_PATCH(JLTS_riot_shield_item);
-    SIMPLE_PATCH(JLTS_scanner_police);
+    SIMPLE_PATCH(JLTS_droidCaller);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -6,4 +6,5 @@ class CfgWeapons
     SIMPLE_PATCH(JLTS_droidCaller);
     SIMPLE_PATCH(JLTS_drugs_electrolit);
     SIMPLE_PATCH(JLTS_ids_gar_navy);
+    SIMPLE_PATCH(JLTS_intel_holocron_jedi);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -7,4 +7,5 @@ class CfgWeapons
     SIMPLE_PATCH(JLTS_drugs_electrolit);
     SIMPLE_PATCH(JLTS_ids_gar_navy);
     SIMPLE_PATCH(JLTS_intel_holocron_jedi);
+    SIMPLE_PATCH(JLTS_repairkit_weapon);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -8,4 +8,5 @@ class CfgWeapons
     SIMPLE_PATCH(JLTS_ids_gar_navy);
     SIMPLE_PATCH(JLTS_intel_holocron_jedi);
     SIMPLE_PATCH(JLTS_repairkit_weapon);
+    SIMPLE_PATCH(JLTS_scanner_police);
 };

--- a/addons/Compats/JLTS/CfgWeapons.hpp
+++ b/addons/Compats/JLTS/CfgWeapons.hpp
@@ -1,0 +1,16 @@
+class CfgWeapons
+{
+    class CBA_MiscItem;
+    class CBA_MiscItem_ItemInfo;
+    class JLTS_credits_10: CBA_MiscItem
+    {
+        detectRange = 0;
+        simulation = "Weapon";
+        type = TYPE_ITEM;
+
+        class ItemInfo: CBA_MiscItem_ItemInfo
+        {
+            type = TYPE_BIPOD;
+        };
+    };
+};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -15,6 +15,7 @@ class CfgPatches
             "A3_Data_F_Decade_Loadorder",
             "MDF_Main",
             QUOTE(ADDON),
+            "JLTS_C_Core",
             "JLTS_C_Credits",
             "JLTS_C_Drugs",
             "JLTS_C_IDs",

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -16,6 +16,7 @@ class CfgPatches
             "MDF_Main",
             QUOTE(ADDON),
             "JLTS_C_Credits",
+            "JLTS_C_Drugs",
             "JLTS_drones_MSE6"
         };
         units[] = {};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+#include "CfgWeapons.hpp"
+
+
+class CfgPatches
+{
+    class SUBADDON
+    {
+        author = "DartRuffian";
+        name = COMPONENT_NAME;
+        addonRootClass = QUOTE(ADDON);
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] =
+        {
+            "A3_Data_F_Decade_Loadorder",
+            "MDF_Main",
+            QUOTE(ADDON),
+            "JLTS_C_Credits"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+    };
+};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -19,6 +19,7 @@ class CfgPatches
             "JLTS_C_Drugs",
             "JLTS_C_IDs",
             "JLTS_C_Intel",
+            "JLTS_weapons_Core",
             "JLTS_drones_MSE6"
         };
         units[] = {};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -21,6 +21,7 @@ class CfgPatches
             "JLTS_C_IDs",
             "JLTS_C_Intel",
             "JLTS_weapons_Core",
+            "JLTS_weapons_shield",
             "JLTS_drones_MSE6"
         };
         units[] = {};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -15,7 +15,8 @@ class CfgPatches
             "A3_Data_F_Decade_Loadorder",
             "MDF_Main",
             QUOTE(ADDON),
-            "JLTS_C_Credits"
+            "JLTS_C_Credits",
+            "JLTS_drones_MSE6"
         };
         units[] = {};
         weapons[] = {};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -18,6 +18,7 @@ class CfgPatches
             "JLTS_C_Credits",
             "JLTS_C_Drugs",
             "JLTS_C_IDs",
+            "JLTS_C_Intel",
             "JLTS_drones_MSE6"
         };
         units[] = {};

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -22,5 +22,7 @@ class CfgPatches
         units[] = {};
         weapons[] = {};
         VERSION_CONFIG;
+
+        skipWhenMissingDependencies = TRUE;
     };
 };

--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -17,6 +17,7 @@ class CfgPatches
             QUOTE(ADDON),
             "JLTS_C_Credits",
             "JLTS_C_Drugs",
+            "JLTS_C_IDs",
             "JLTS_drones_MSE6"
         };
         units[] = {};

--- a/addons/Compats/JLTS/script_component.hpp
+++ b/addons/Compats/JLTS/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT JLTS
+
+#include "..\script_component.hpp"

--- a/addons/Compats/JLTSC/CfgWeapons.hpp
+++ b/addons/Compats/JLTSC/CfgWeapons.hpp
@@ -1,0 +1,10 @@
+class CfgWeapons
+{
+    class CBA_MiscItem;
+    class CBA_MiscItem_ItemInfo;
+    SIMPLE_PATCH(JLTS_scanner_police);
+    SIMPLE_PATCH(JLTS_credits_10);
+    SIMPLE_PATCH(JLTS_drugs_electrolit);
+    SIMPLE_PATCH(JLTS_ids_gar_navy);
+    SIMPLE_PATCH(JLTS_intel_holocron_jedi);
+};

--- a/addons/Compats/JLTSC/config.cpp
+++ b/addons/Compats/JLTSC/config.cpp
@@ -15,9 +15,11 @@ class CfgPatches
             "A3_Data_F_Decade_Loadorder",
             "MDF_Main",
             QUOTE(ADDON),
-            "JLTS_weapons_Core",
-            "JLTS_weapons_shield",
-            "JLTS_drones_MSE6"
+            "JLTS_C_Core",
+            "JLTS_C_Credits",
+            "JLTS_C_Drugs",
+            "JLTS_C_IDs",
+            "JLTS_C_Intel"
         };
         units[] = {};
         weapons[] = {};

--- a/addons/Compats/JLTSC/config.cpp
+++ b/addons/Compats/JLTSC/config.cpp
@@ -24,5 +24,7 @@ class CfgPatches
         units[] = {};
         weapons[] = {};
         VERSION_CONFIG;
+
+        skipWhenMissingDependencies = TRUE;
     };
 };

--- a/addons/Compats/JLTSC/script_component.hpp
+++ b/addons/Compats/JLTSC/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT JLTSC
+
+#include "..\script_component.hpp"

--- a/addons/Compats/script_component.hpp
+++ b/addons/Compats/script_component.hpp
@@ -3,3 +3,4 @@
 
 #include "\DA\MDF\Main\script_mod.hpp"
 #include "\DA\MDF\Main\script_macros.hpp"
+#include "\DA\MDF\Compats\script_macros.hpp"

--- a/addons/Compats/script_macros.hpp
+++ b/addons/Compats/script_macros.hpp
@@ -1,0 +1,10 @@
+#define SIMPLE_PATCH(CLASSNAME) class CLASSNAME##: CBA_MiscItem \
+{ \
+    detectRange = 0; \
+    simulation = "Weapon"; \
+    type = TYPE_ITEM; \
+    class ItemInfo: CBA_MiscItem_ItemInfo \
+    { \
+        type = TYPE_BIPOD; \
+    }; \
+}

--- a/addons/Main/script_macros.hpp
+++ b/addons/Main/script_macros.hpp
@@ -1,4 +1,7 @@
 #include "\x\cba\addons\main\script_macros_common.hpp"
 
+#define TYPE_BIPOD 302
+#define TYPE_ITEM 131072
+
 #define TRUE 1
 #define FALSE 0

--- a/addons/Main/script_version.hpp
+++ b/addons/Main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
 #define MINOR 0
 #define PATCH 0
-#define BUILD 1
+#define BUILD 2

--- a/extras/compat/CfgWeapons.hpp
+++ b/extras/compat/CfgWeapons.hpp
@@ -1,5 +1,5 @@
 class CfgWeapons
 {
     class CBA_MiscItem;
-    class CBA_MiscItemInfo;
+    class CBA_MiscItem_ItemInfo;
 };

--- a/extras/compat/config.cpp
+++ b/extras/compat/config.cpp
@@ -20,5 +20,7 @@ class CfgPatches
         units[] = {};
         weapons[] = {};
         VERSION_CONFIG;
+
+        skipWhenMissingDependencies = TRUE;
     };
 };


### PR DESCRIPTION
### Description
Fixes JLTS inventory items breaking mine detectors.
Closes #1 

### Changes
**Main Compat Addon**
- Added macro for simple fixes, updates base class for given class and the class's `ItemInfo` class.

**Compat - JLTS**
- Simple patch applied to:
  - `JLTS_repairkit_weapon`
  - `JLTS_riot_shield_item`
  - `JLTS_droidCaller`
  
**Compat - JLTS Contraband**
  - `JLTS_scanner_police`
  - `JLTS_credits_10`
  - `JLTS_drugs_electrolit`
  - `JLTS_ids_gar_navy`
  - `JLTS_intel_holocron_jedi`

**Tools**
- Added JLTS launch option
- Added missing `skipWhenMissingDependencies` to example patch