### PR TITLE
Readme

### DIFF
--- a/.hemtt/hooks/post_build/01_move_readme.rhai
+++ b/.hemtt/hooks/post_build/01_move_readme.rhai
@@ -1,0 +1,4 @@
+let readme = "README.md";
+HEMTT_VFS.join("docs")
+    .join(readme)
+    .move(HEMTT_VFS.join(readme));

--- a/.hemtt/hooks/post_build/01_move_readme.rhai
+++ b/.hemtt/hooks/post_build/01_move_readme.rhai
@@ -1,4 +1,0 @@
-let readme = "README.md";
-HEMTT_VFS.join("docs")
-    .join(readme)
-    .move(HEMTT_VFS.join(readme));

--- a/.hemtt/hooks/post_release/01_move_readme.rhai
+++ b/.hemtt/hooks/post_release/01_move_readme.rhai
@@ -1,0 +1,13 @@
+let readme = HEMTT_RFS.join("docs")
+    .join("README.md")
+    .open_file()
+    .read();
+readme.replace("0.0.0",
+    HEMTT.project()
+    .version()
+    .to_string_short()
+);
+HEMTT_RFS.join("README.md")
+    .create_file()
+    .write(readme);
+print("README.md version set to " + HEMTT.project().version());

--- a/.hemtt/hooks/pre_build/01_set_version.rhai
+++ b/.hemtt/hooks/pre_build/01_set_version.rhai
@@ -2,21 +2,25 @@ let modcpp = HEMTT_VFS.join("mod.cpp")
     .open_file()
     .read();
 modcpp.replace("0.0.0",
-    HEMTT.project().
-    version().
-    to_string_short()
+    HEMTT.project()
+    .version()
+    .to_string_short()
 );
 HEMTT_VFS.join("mod.cpp")
     .create_file()
     .write(modcpp);
 print("mod.cpp version set");
 
-let readme = "README.md";
-let readmemd = HEMTT_VFS.join("docs").join(readme)
+
+let readme = HEMTT_VFS.join("README.md")
     .open_file()
     .read();
-readmemd.replace("0.0.0", HEMTT.project().version().to_string_short());
-HEMTT_VFS.join("docs").join(readme)
+readme.replace("0.0.0",
+    HEMTT.project()
+    .version()
+    .to_string_short()
+);
+HEMTT_VFS.join("README.md")
     .create_file()
-    .write(readmemd);
-print(readme + " version set");
+    .write(readme);
+print("README.md version set");

--- a/.hemtt/hooks/pre_build/01_set_version.rhai
+++ b/.hemtt/hooks/pre_build/01_set_version.rhai
@@ -23,4 +23,4 @@ readme.replace("0.0.0",
 HEMTT_VFS.join("README.md")
     .create_file()
     .write(readme);
-print("README.md version set");
+print("README.md version set to " + HEMTT.project().version());

--- a/.hemtt/hooks/pre_build/01_set_version.rhai
+++ b/.hemtt/hooks/pre_build/01_set_version.rhai
@@ -12,11 +12,11 @@ HEMTT_VFS.join("mod.cpp")
 print("mod.cpp version set");
 
 let readme = "README.md";
-let readmemd = HEMTT_VFS.join(readme)
+let readmemd = HEMTT_VFS.join("docs").join(readme)
     .open_file()
     .read();
 readmemd.replace("0.0.0", HEMTT.project().version().to_string_short());
-HEMTT_VFS.join(readme)
+HEMTT_VFS.join("docs").join(readme)
     .create_file()
     .write(readmemd);
 print(readme + " version set");

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
         <img src="https://img.shields.io/github/issues-raw/DartRuffian/Mine-Detector-Fixes.svg?style=flat-square&label=Issues" alt="MDF Issues">
     </a>
     <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases">
-        <img src="https://img.shields.io/steam/downloads/.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
+        <img src="https://img.shields.io/steam/downloads/3086321202.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
     </a>
     <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-APL-red.svg?style=flat-square" alt="MDF License">

--- a/README.md
+++ b/README.md
@@ -1,11 +1,42 @@
-## Mine Detector Fixes
-**Version 0.0.0**
+# <center>Mine Detector Fixes</center>
+<p align="center">
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases/latest">
+        <img src="https://img.shields.io/badge/Version-1.1.0-blue.svg?style=flat-square" alt="MDF Version">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/issues">
+        <img src="https://img.shields.io/github/issues-raw/DartRuffian/Mine-Detector-Fixes.svg?style=flat-square&label=Issues" alt="MDF Issues">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases">
+        <img src="https://img.shields.io/steam/downloads/.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE">
+        <img src="https://img.shields.io/badge/License-APL-red.svg?style=flat-square" alt="MDF License">
+    </a>
+</p>
 
-### Description
+**Mine-Detector-Fixes** (MDF) aims to serve as an "all-in-one" mod to fix various mods breaking vanilla mine detectors, which can be very frustrating for players.
 
-A collection of fixes to fix items from various mods breaking vanilla mine detectors. This is a very common error when mods use the vanilla game's `ItemCore` class instead of the `CBA_MiscItem` class from [Community Based Addons](https://steamcommunity.com/workshop/filedetails/?id=450814997). The issue is caused by miscellaneous items actually being mine detectors with a `detectRange` of 0, and modded items sometimes configure values improperly.
+The project is entirely **open-source** and any contributions to fix other mods are welcome.
 
----
+While containing fixes for several mods, only patches for mods that players have enabled when launching arma will be loaded using the `skipWhenMissingDependencies` flag. This ensures that missing addon or missing class errors will not occur.
 
-[GitHub](https://github.com/DartRuffian/Mine-Detector-Fixes)
-[Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=2936216405)
+## Available Patches
+
+- [Just Like The Simulations - The Great War](https://steamcommunity.com/sharedfiles/filedetails/?id=1940589429)
+- [Just Like The Simulations - Contraband](https://steamcommunity.com/sharedfiles/filedetails/?id=1875369298)
+
+## Contributing
+
+Users are welcome to create a compatability patch for a mod by using the [example patch](https://github.com/DartRuffian/Mine-Detector-Fixes/tree/main/extras/compat) as a base.
+
+### Submitting issues and requesting patches
+
+If you find a bug in the mod or want to request a compatability patch for another mod, you can do so on the [Issue Tracker](https://github.com/DartRuffian/Mine-Detector-Fixes/issues). Be sure to apply the appropiate label for what you are reporting.
+
+### Testing & building
+
+MDF is built using [HEMTT](https://github.com/BrettMayson/HEMTT). There are several build files included in [Tools/](https://github.com/DartRuffian/Mine-Detector-Fixes/tree/main/Tools) to automatically update the mod version when building and releasing.
+
+## License
+
+ACE3 is licensed under the Arma Public Licence ([APL](https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE)).

--- a/addons/Main/script_version.hpp
+++ b/addons/Main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 1
-#define MINOR 0
+#define MINOR 1
 #define PATCH 0
 #define BUILD 2

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
         <img src="https://img.shields.io/github/issues-raw/DartRuffian/Mine-Detector-Fixes.svg?style=flat-square&label=Issues" alt="MDF Issues">
     </a>
     <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases">
-        <img src="https://img.shields.io/steam/downloads/.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
+        <img src="https://img.shields.io/steam/downloads/3086321202.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
     </a>
     <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-APL-red.svg?style=flat-square" alt="MDF License">

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# <center>Mine Detector Fixes</center>
+<p align="center">
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases/latest">
+        <img src="https://img.shields.io/badge/Version-0.0.0-blue.svg?style=flat-square" alt="MDF Version">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/issues">
+        <img src="https://img.shields.io/github/issues-raw/DartRuffian/Mine-Detector-Fixes.svg?style=flat-square&label=Issues" alt="MDF Issues">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/releases">
+        <img src="https://img.shields.io/steam/downloads/.svg?style=flat-square&label=Downloads" alt="MDF Downloads">
+    </a>
+    <a href="https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE">
+        <img src="https://img.shields.io/badge/License-APL-red.svg?style=flat-square" alt="MDF License">
+    </a>
+</p>
+
+**Mine-Detector-Fixes** (MDF) aims to serve as an "all-in-one" mod to fix various mods breaking vanilla mine detectors, which can be very frustrating for players.
+
+The project is entirely **open-source** and any contributions to fix other mods are welcome.
+
+While containing fixes for several mods, only patches for mods that players have enabled when launching arma will be loaded using the `skipWhenMissingDependencies` flag. This ensures that missing addon or missing class errors will not occur.
+
+## Available Patches
+
+- [Just Like The Simulations - The Great War](https://steamcommunity.com/sharedfiles/filedetails/?id=1940589429)
+- [Just Like The Simulations - Contraband](https://steamcommunity.com/sharedfiles/filedetails/?id=1875369298)
+
+## Contributing
+
+Users are welcome to create a compatability patch for a mod by using the [example patch](https://github.com/DartRuffian/Mine-Detector-Fixes/tree/main/extras/compat) as a base.
+
+### Submitting issues and requesting patches
+
+If you find a bug in the mod or want to request a compatability patch for another mod, you can do so on the [Issue Tracker](https://github.com/DartRuffian/Mine-Detector-Fixes/issues). Be sure to apply the appropiate label for what you are reporting.
+
+### Testing & building
+
+MDF is built using [HEMTT](https://github.com/BrettMayson/HEMTT). There are several build files included in [Tools/](https://github.com/DartRuffian/Mine-Detector-Fixes/tree/main/Tools) to automatically update the mod version when building and releasing.
+
+## License
+
+ACE3 is licensed under the Arma Public Licence ([APL](https://github.com/DartRuffian/Mine-Detector-Fixes/blob/main/LICENSE)).


### PR DESCRIPTION
### Description
New README, updated HEMTT hooks to automatically update version in README and move from `./docs/` to `./`.

### Changes
- Updated README.
- Formatted HEMTT hooks, removed unnecessary variable
- `set_version` now displays the HEMTT project version
- Moved `move_readme` from `post_build` to `post_release`