### PR TITLE
Example compat fixes

### DIFF
--- a/addons/Compats/JLTS/config.cpp
+++ b/addons/Compats/JLTS/config.cpp
@@ -12,8 +12,6 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] =
         {
-            "A3_Data_F_Decade_Loadorder",
-            "MDF_Main",
             QUOTE(ADDON),
             "JLTS_weapons_Core",
             "JLTS_weapons_shield",

--- a/addons/Compats/JLTSC/config.cpp
+++ b/addons/Compats/JLTSC/config.cpp
@@ -12,8 +12,6 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] =
         {
-            "A3_Data_F_Decade_Loadorder",
-            "MDF_Main",
             QUOTE(ADDON),
             "JLTS_C_Core",
             "JLTS_C_Credits",

--- a/addons/Compats/WBKLightsaber/config.cpp
+++ b/addons/Compats/WBKLightsaber/config.cpp
@@ -12,8 +12,6 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] =
         {
-            "A3_Data_F_Decade_Loadorder",
-            "MDF_Main",
             QUOTE(ADDON),
             "WBK_SomeSciFiWeapons"
         };

--- a/addons/Compats/config.cpp
+++ b/addons/Compats/config.cpp
@@ -10,7 +10,6 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] =
         {
-            "A3_Data_F_Decade_Loadorder",
             "cba_common",
             "MDF_Main"
         };

--- a/addons/Compats/config.cpp
+++ b/addons/Compats/config.cpp
@@ -11,6 +11,7 @@ class CfgPatches
         requiredAddons[] =
         {
             "A3_Data_F_Decade_Loadorder",
+            "cba_common",
             "MDF_Main"
         };
         units[] = {};

--- a/extras/compat/config.cpp
+++ b/extras/compat/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches
 {
     class SUBADDON
     {
-        author = "DartRuffian";
+        author = "Your Name";
         name = COMPONENT_NAME;
         addonRootClass = QUOTE(ADDON);
         requiredVersion = REQUIRED_VERSION;

--- a/extras/compat/config.cpp
+++ b/extras/compat/config.cpp
@@ -12,9 +12,6 @@ class CfgPatches
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] =
         {
-            "A3_Data_F_Decade_Loadorder",
-            "cba_common",
-            "MDF_Main",
             QUOTE(ADDON)
         };
         units[] = {};


### PR DESCRIPTION
### Description
Small fixes to the example compatibility patch and all current patches.

### Changes
- Changed `author` in example patch to `"Your Name"` instead of `"DartRuffian"`.
- Added `cba_common` to `requiredAddons` of root addon for compats.
- Removed Arma 3 load order and `MDF_Main` as required addons for all compats.
  - Not explicitly needed since all compats are depdentant on the root addon, which already requires both.