### PR TITLE
cTab Compatibility Patch

### DIFF
--- a/addons/Compats/CTAB/CfgWeapons.hpp
+++ b/addons/Compats/CTAB/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons
+{
+    class CBA_MiscItem;
+    class CBA_MiscItem_ItemInfo;
+    SIMPLE_PATCH(ItemcTabHCam);
+};

--- a/addons/Compats/CTAB/config.cpp
+++ b/addons/Compats/CTAB/config.cpp
@@ -1,0 +1,26 @@
+#include "script_component.hpp"
+#include "CfgWeapons.hpp"
+
+// Works for both cTab and cTab NSWDG edition
+// Will likely work for other ctab versions as well
+
+class CfgPatches
+{
+    class SUBADDON
+    {
+        author = "DartRuffian";
+        name = COMPONENT_NAME;
+        addonRootClass = QUOTE(ADDON);
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] =
+        {
+            QUOTE(ADDON),
+            "cTab"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = TRUE;
+    };
+};

--- a/addons/Compats/CTAB/script_component.hpp
+++ b/addons/Compats/CTAB/script_component.hpp
@@ -1,0 +1,3 @@
+#define SUBCOMPONENT CTAB
+
+#include "..\script_component.hpp"


### PR DESCRIPTION
### Description
Fixes [cTab](https://steamcommunity.com/sharedfiles/filedetails/?id=871504836) and [cTab NSWDG Edition](http://steamcommunity.com/sharedfiles/filedetails/?id=2511318948) inventory items breaking mine detectors.
Closes #Issue Number

### Changes
**Compat -cTab**
- Simple patch applied to:
  - `ItemcTabHCam`