### PR TITLE
ACE Placeables Compat

### DIFF
--- a/addons/Compats/ACE_Placeables/CfgWeapons.hpp
+++ b/addons/Compats/ACE_Placeables/CfgWeapons.hpp
@@ -1,0 +1,6 @@
+class CfgWeapons
+{
+    class CBA_MiscItem;
+    class CBA_MiscItem_ItemInfo;
+    SIMPLE_PATCH(kka3_itemcore);
+};

--- a/addons/Compats/ACE_Placeables/CfgWeapons.hpp
+++ b/addons/Compats/ACE_Placeables/CfgWeapons.hpp
@@ -3,4 +3,69 @@ class CfgWeapons
     class CBA_MiscItem;
     class CBA_MiscItem_ItemInfo;
     SIMPLE_PATCH(kka3_itemcore);
+    // Each item redefines ItemInfo instead of inheriting from kka3_itemcore
+    class kka3_ace_extension_Campfire_burning_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_BagFence_Long_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_BagFence_Round_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_Camping_Light_off_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_CampingChair_V1_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_CampingTable_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_DrillAku_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_Pallet_vertical_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_PortableLight_single_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Land_Wrench_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_roadbarrier_f: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_roadbarrier_small_f: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_roadcone_f: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_roadcone_l_f: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_TapeSign_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
+    class kka3_ace_extension_Target_F: kka3_itemcore
+    {
+        class ItemInfo: ItemInfo {};
+    };
 };

--- a/addons/Compats/ACE_Placeables/config.cpp
+++ b/addons/Compats/ACE_Placeables/config.cpp
@@ -1,0 +1,24 @@
+#include "script_component.hpp"
+#include "CfgWeapons.hpp"
+
+
+class CfgPatches
+{
+    class SUBADDON
+    {
+        author = "DartRuffian";
+        name = COMPONENT_NAME;
+        addonRootClass = QUOTE(ADDON);
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] =
+        {
+            QUOTE(ADDON),
+            "KKA3_ACE_Extension_Placeables_Items"
+        };
+        units[] = {};
+        weapons[] = {};
+        VERSION_CONFIG;
+
+        skipWhenMissingDependencies = TRUE;
+    };
+};

--- a/addons/Compats/ACE_Placeables/script_component.hpp
+++ b/addons/Compats/ACE_Placeables/script_component.hpp
@@ -1,0 +1,4 @@
+#define SUBCOMPONENT ACE_PLACEABLES
+#define SUBCOMPONENT_BEAUTIFIED ACE - Placeables
+
+#include "..\script_component.hpp"

--- a/addons/Compats/ACE_Placeables/script_component.hpp
+++ b/addons/Compats/ACE_Placeables/script_component.hpp
@@ -1,4 +1,4 @@
-#define SUBCOMPONENT ACE_PLACEABLES
+#define SUBCOMPONENT ACE_Placeables
 #define SUBCOMPONENT_BEAUTIFIED ACE - Placeables
 
 #include "..\script_component.hpp"


### PR DESCRIPTION
### Description
Fixes [ACE 3 Extension (Placeables)](https://steamcommunity.com/sharedfiles/filedetails/?id=866772689&searchtext=ace) inventory items breaking mine detectors.

### Changes
**Compat - ACE Placeables**
- Simple patch applied to:
  - `kka3_itemcore`
- Manual inheritances fixes for
  - `kka3_ace_extension_Campfire_burning_F`
  - `kka3_ace_extension_Land_BagFence_Long_F`
  - `kka3_ace_extension_Land_BagFence_Round_F`
  - `kka3_ace_extension_Land_Camping_Light_off_F`
  - `kka3_ace_extension_Land_CampingChair_V1_F`
  - `kka3_ace_extension_Land_CampingTable_F`
  - `kka3_ace_extension_Land_DrillAku_F`
  - `kka3_ace_extension_Land_Pallet_vertical_F`
  - `kka3_ace_extension_Land_PortableLight_single_F`
  - `kka3_ace_extension_Land_Wrench_F`
  - `kka3_ace_extension_roadbarrier_f`
  - `kka3_ace_extension_roadbarrier_small_f`
  - `kka3_ace_extension_roadcone_f`
  - `kka3_ace_extension_roadcone_l_f`
  - `kka3_ace_extension_TapeSign_F`
  - `kka3_ace_extension_Target_F`